### PR TITLE
Ensures zmq::thread_ctx_t::get/set dont zmq_abort() on invalid option *unless* the library is built with ZMQ_ACT_MILITANT

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -605,7 +605,10 @@ int zmq::thread_ctx_t::set (int option_, const void *optval_, size_t optvallen_)
             break;
 
         default:
+#if defined(ZMQ_ACT_MILITANT)
             zmq_abort ("Invalid option");
+#endif
+            break;
     }
 
     errno = EINVAL;
@@ -642,7 +645,10 @@ int zmq::thread_ctx_t::get (int option_,
             break;
 
         default:
+#if defined(ZMQ_ACT_MILITANT)
             zmq_abort ("Invalid option");
+#endif
+            break;
     }
 
     errno = EINVAL;


### PR DESCRIPTION
Ensures zmq::thread_ctx_t::get/set dont zmq_abort() on invalid option *unless* the library is built with ZMQ_ACT_MILITANT