### PR TITLE
Fixing SEGV #4524. Pipe should only send to peer when active. (#4647)

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -539,7 +539,8 @@ bool zmq::pipe_t::check_hwm () const
 
 void zmq::pipe_t::send_hwms_to_peer (int inhwm_, int outhwm_)
 {
-    send_pipe_hwm (_peer, inhwm_, outhwm_);
+    if (_state == active)
+        send_pipe_hwm (_peer, inhwm_, outhwm_);
 }
 
 void zmq::pipe_t::set_endpoint_pair (zmq::endpoint_uri_pair_t endpoint_pair_)
@@ -554,10 +555,12 @@ const zmq::endpoint_uri_pair_t &zmq::pipe_t::get_endpoint_pair () const
 
 void zmq::pipe_t::send_stats_to_peer (own_t *socket_base_)
 {
-    endpoint_uri_pair_t *ep =
-      new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
-    send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read, socket_base_,
-                          ep);
+    if (_state == active) {
+        endpoint_uri_pair_t *ep =
+          new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
+        send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read,
+                              socket_base_, ep);
+    }
 }
 
 void zmq::pipe_t::process_pipe_peer_stats (uint64_t queue_count_,


### PR DESCRIPTION
* Fixing SEGV #4524. Pipe should only send to peer when active.