### PR TITLE
Fix Autotools-generated `libzmq.pc` file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,7 @@ case "${host_os}" in
 
         if test "x$enable_static" = "xyes"; then
             CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
-            PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -liphlpapi"
+            PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -liphlpapi -lws2_32"
         fi
 	# Set FD_SETSIZE to 16384
 	CPPFLAGS=" -DFD_SETSIZE=16384 $CPPFLAGS"


### PR DESCRIPTION
This change fixes cross-compiling for Windows with static linking.